### PR TITLE
Set up CI/CD with Github Actions

### DIFF
--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -11,8 +11,8 @@ jobs:
       - name: Get repository code
         uses: actions/checkout@v2
         
-      - name: Create build directory and cd to it
-        run: mkdir build && cd build
+      - name: Create build directory
+        run: mkdir build
         
       - name: Download Windows NW.js
         run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-win-x64.zip
@@ -29,8 +29,8 @@ jobs:
       - name: Delete archives
         run: rm nwjs-v0.55.0-linux-x64.tar.gz nwjs-v0.55.0-win-x64.zip
         
-      - name: Rename NW.js directories
-        run: mv nwjs-v0.55.0-linux-x64 KitsuneOffline-linux && mv nwjs-v0.55.0-win-x64 KitsuneOffline-win
+      - name: Rename and move NW.js directories
+        run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win
         
       - name: list files to make sure we are on the right track
-        run: echo "Build directory:" && ls -A && echo "Repository:" && ls -A ..
+        run: echo "Build directory:" && ls -A build && echo "Repository:" && ls -A

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Download Linux ia32 NW.js
         run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-linux-ia32.tar.gz
         
+      - name: Download MacOS NW.js
+        run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-osx-x64.zip
+        
       - name: Extract Windows x64 NW.js
         run: unzip nwjs-v0.55.0-win-x64.zip
         
@@ -38,20 +41,23 @@ jobs:
       - name: Extract Linux ia32 NW.js
         run: tar -xvf nwjs-v0.55.0-linux-ia32.tar.gz
         
+      - name: Extract MacOS NW.js
+        run: unzip nwjs-v0.55.0-osx-x64.zip
+        
       - name: Delete archives
-        run: rm nwjs-v0.55.0-linux-x64.tar.gz nwjs-v0.55.0-win-x64.zip nwjs-v0.55.0-linux-ia32.tar.gz nwjs-v0.55.0-win-ia32.zip
+        run: rm nwjs-v0.55.0-linux-x64.tar.gz nwjs-v0.55.0-win-x64.zip nwjs-v0.55.0-linux-ia32.tar.gz nwjs-v0.55.0-win-ia32.zip nwjs-v0.55.0-osx-x64.zip
         
       - name: Rename and move NW.js directories
-        run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux-x64 && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win-x64 && mv nwjs-v0.55.0-linux-ia32 build/KitsuneOffline-linux-ia32 && mv nwjs-v0.55.0-win-ia32 build/KitsuneOffline-win-ia32
+        run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux-x64 && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win-x64 && mv nwjs-v0.55.0-linux-ia32 build/KitsuneOffline-linux-ia32 && mv nwjs-v0.55.0-win-ia32 build/KitsuneOffline-win-ia32 && mv nwjs-v0.55.0-osx-x64.app build/Kitsune.app
         
       - name: Create package.nw directories
-        run: mkdir build/KitsuneOffline-linux-x64/package.nw && mkdir build/KitsuneOffline-win-x64/package.nw && mkdir build/KitsuneOffline-linux-ia32/package.nw && mkdir build/KitsuneOffline-win-ia32/package.nw
+        run: mkdir build/KitsuneOffline-linux-x64/package.nw && mkdir build/KitsuneOffline-win-x64/package.nw && mkdir build/KitsuneOffline-linux-ia32/package.nw && mkdir build/KitsuneOffline-win-ia32/package.nw && mkdir build/Kitsune.app/Contents/Resources/app.nw
         
       - name: Copy logos to NW.js directories
-        run: cp -r logos build/KitsuneOffline-linux-x64/package.nw && cp -r logos build/KitsuneOffline-win-x64/package.nw && cp -r logos build/KitsuneOffline-linux-ia32/package.nw && cp -r logos build/KitsuneOffline-win-ia32/package.nw
+        run: cp -r logos build/KitsuneOffline-linux-x64/package.nw && cp -r logos build/KitsuneOffline-win-x64/package.nw && cp -r logos build/KitsuneOffline-linux-ia32/package.nw && cp -r logos build/KitsuneOffline-win-ia32/package.nw && cp -r logos build/Kitsune.app/Contents/Resources/app.nw
         
       - name: Copy package.json to NW.js directories
-        run: cp package.json build/KitsuneOffline-linux-x64/package.nw && cp package.json build/KitsuneOffline-win-x64/package.nw && cp package.json build/KitsuneOffline-linux-ia32/package.nw && cp package.json build/KitsuneOffline-win-ia32/package.nw
+        run: cp package.json build/KitsuneOffline-linux-x64/package.nw && cp package.json build/KitsuneOffline-win-x64/package.nw && cp package.json build/KitsuneOffline-linux-ia32/package.nw && cp package.json build/KitsuneOffline-win-ia32/package.nw && cp package.json build/Kitsune.app/Contents/Resources/app.nw
     
       - name: Rename executables
         run: mv build/KitsuneOffline-linux-x64/nw build/KitsuneOffline-linux-x64/kitsune && mv build/KitsuneOffline-linux-ia32/nw build/KitsuneOffline-linux-ia32/kitsune && mv build/KitsuneOffline-win-x64/nw.exe build/KitsuneOffline-win-x64/kitsune.exe && mv build/KitsuneOffline-win-ia32/nw.exe build/KitsuneOffline-win-ia32/kitsune.exe
@@ -78,7 +84,10 @@ jobs:
         run: cd build && zip -r KitsuneOffline-win-x64.zip KitsuneOffline-win-x64 && zip -r KitsuneOffline-win-ia32.zip KitsuneOffline-win-ia32
         
       - name: Create Linux archives
-        run: cd build && tar -czvf KitsuneOffline-linux-x64.tar.gz KitsuneOffline-linux-x64 && zip -r KitsuneOffline-linux-ia32.tar.gz KitsuneOffline-linux-ia32
+        run: cd build && tar -czvf KitsuneOffline-linux-x64.tar.gz KitsuneOffline-linux-x64 && tar -czvf KitsuneOffline-linux-ia32.tar.gz KitsuneOffline-linux-ia32
+        
+      - name: Create MacOS archives
+        run: cd build && zip -r KitsuneOffline-osx.zip Kitsune.app
         
       - name: Upload Windows x64 build
         uses: actions/upload-artifact@v2
@@ -109,3 +118,9 @@ jobs:
         with:
           name: KitsuneOffline-debian-x64.deb
           path: build/KitsuneOffline-debian-x64.deb
+
+      - name: Upload MacOS build
+        uses: actions/upload-artifact@v2
+        with:
+          name: KitsuneOffline-osx.zip
+          path: build/KitsuneOffline-osx.zip

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -32,5 +32,21 @@ jobs:
       - name: Rename and move NW.js directories
         run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win
         
-      - name: list files to make sure we are on the right track
+      - name: List files to make sure we are on the right track, which we should be!
         run: echo "Build directory:" && ls -A build && echo "Repository:" && ls -A
+        
+      - name: Create package.nw directories
+        run: mkdir build/KitsuneOffline-linux/package.nw && mkdir build/KitsuneOffline-win/package.nw
+        
+      - name: Copy code to NW.js directories
+        run: cp -r logos build/KitsuneOffline-linux/package.nw && cp package.json build/KitsuneOffline-linux/package.nw && cp -r logos build/KitsuneOffline-win/package.nw && cp package.json build/KitsuneOffline-win/package.nw
+        
+      - name: create Windows archive
+        run: cd build && zip -r KitsuneOffline-win.zip KitsuneOffline-win
+        
+      - name: create Linux archive
+        run: cd build && tar -czvf KitsuneOffline-linux.tar.gz KitsuneOffline-linux
+        
+      - name: list files again
+        run: echo "Build directory:" && ls -A build && echo "Repository:" && ls -A
+        

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -72,7 +72,7 @@ jobs:
         run: cp kitsune.desktop build/KitsuneOffline-debian-x64/usr/share/applications
         
       - name: Create Debian installer
-        run: cd build && dpkg-deb --build KitsuneOffline-Debian-x64
+        run: cd build && dpkg-deb --build KitsuneOffline-debian-x64
 
       - name: Create Windows archives
         run: cd build && zip -r KitsuneOffline-win-x64.zip KitsuneOffline-win-x64 && zip -r KitsuneOffline-win-ia32.zip KitsuneOffline-win-ia32

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -48,7 +48,7 @@ jobs:
         run: rm nwjs-v0.55.0-linux-x64.tar.gz nwjs-v0.55.0-win-x64.zip nwjs-v0.55.0-linux-ia32.tar.gz nwjs-v0.55.0-win-ia32.zip nwjs-v0.55.0-osx-x64.zip
         
       - name: Rename and move NW.js directories
-        run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux-x64 && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win-x64 && mv nwjs-v0.55.0-linux-ia32 build/KitsuneOffline-linux-ia32 && mv nwjs-v0.55.0-win-ia32 build/KitsuneOffline-win-ia32 && mv nwjs.app build/Kitsune.app
+        run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux-x64 && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win-x64 && mv nwjs-v0.55.0-linux-ia32 build/KitsuneOffline-linux-ia32 && mv nwjs-v0.55.0-win-ia32 build/KitsuneOffline-win-ia32 && mv nwjs-v0.55.0-osx-x64/nwjs.app build/Kitsune.app
         
       - name: Create package.nw directories
         run: mkdir build/KitsuneOffline-linux-x64/package.nw && mkdir build/KitsuneOffline-win-x64/package.nw && mkdir build/KitsuneOffline-linux-ia32/package.nw && mkdir build/KitsuneOffline-win-ia32/package.nw && mkdir build/Kitsune.app/Contents/Resources/app.nw

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -14,16 +14,28 @@ jobs:
       - name: Create build directory
         run: mkdir build
         
-      - name: Download Windows NW.js
+      - name: Download Windows x64 NW.js
         run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-win-x64.zip
         
-      - name: Extract Windows NW.js
-        run: unzip nwjs-v0.55.0-win-x64.zip
-      
-      - name: Download Linux NW.js
+      - name: Download Windows x86 NW.js
+        run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-win-x86.zip
+        
+      - name: Download Linux x64 NW.js
         run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-linux-x64.tar.gz
         
-      - name: Extract Linux NW.js
+      - name: Download Linux x86 NW.js
+        run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-linux-x86.tar.gz
+        
+      - name: Extract Windows x64 NW.js
+        run: unzip nwjs-v0.55.0-win-x64.zip
+        
+      - name: Extract Windows x86 NW.js
+        run: unzip nwjs-v0.55.0-win-x86.zip
+        
+      - name: Extract Linux x64 NW.js
+        run: tar -xvf nwjs-v0.55.0-linux-x64.tar.gz
+        
+      - name: Extract Linux x64 NW.js
         run: tar -xvf nwjs-v0.55.0-linux-x64.tar.gz
         
       - name: Delete archives

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -48,7 +48,7 @@ jobs:
         run: rm nwjs-v0.55.0-linux-x64.tar.gz nwjs-v0.55.0-win-x64.zip nwjs-v0.55.0-linux-ia32.tar.gz nwjs-v0.55.0-win-ia32.zip nwjs-v0.55.0-osx-x64.zip
         
       - name: Rename and move NW.js directories
-        run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux-x64 && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win-x64 && mv nwjs-v0.55.0-linux-ia32 build/KitsuneOffline-linux-ia32 && mv nwjs-v0.55.0-win-ia32 build/KitsuneOffline-win-ia32 && mv nwjs-v0.55.0-osx-x64.app build/Kitsune.app
+        run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux-x64 && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win-x64 && mv nwjs-v0.55.0-linux-ia32 build/KitsuneOffline-linux-ia32 && mv nwjs-v0.55.0-win-ia32 build/KitsuneOffline-win-ia32 && mv nwjs.app build/Kitsune.app
         
       - name: Create package.nw directories
         run: mkdir build/KitsuneOffline-linux-x64/package.nw && mkdir build/KitsuneOffline-win-x64/package.nw && mkdir build/KitsuneOffline-linux-ia32/package.nw && mkdir build/KitsuneOffline-win-ia32/package.nw && mkdir build/Kitsune.app/Contents/Resources/app.nw

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -33,4 +33,4 @@ jobs:
         run: mv nwjs-v0.55.0-linux-x64 KitsuneOffline-linux && mv nwjs-v0.55.0-win-x64 KitsuneOffline-win
         
       - name: list files to make sure we are on the right track
-        run: ls && ls ..
+        run: echo "Build directory:" && ls -A && echo "Repository:" && ls -A ..

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -1,30 +1,27 @@
-name: BUild NW.js apps
+name: Build NW.js apps
 
 on:
   [push, workflow_dispatch]
   
 jobs:
   build:
-    name: BUild Windows app
+    name: Build NW.js apps
     runs-on: ubuntu-latest
     steps:
       - name: Get repository code
         uses: actions/checkout@v2
         
-      - name: Download NW.js
+      - name: Download Windows NW.js
         run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-win-x64.zip
         
-      - name: Extract NW.js
+      - name: Extract Windows NW.js
         run: unzip nwjs-v0.55.0-win-x64.zip
-  build:
-    name: Build Linux app
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get repository code
-        uses: actions/checkout@v2
       
-      - name: Download NW.js
+      - name: Download Linux NW.js
         run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-linux-x64.tar.gz
         
-      - name: Extract NW.js
+      - name: Extract Linux NW.js
         run: unzip nwjs-v0.55.0-linux-x64.tar.gz
+        
+      - name: list files
+        run: ls

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Rename and move NW.js directories
         run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux-x64 && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win-x64 && mv nwjs-v0.55.0-linux-ia32 build/KitsuneOffline-linux-ia32 && mv nwjs-v0.55.0-win-ia32 build/KitsuneOffline-win-ia32
         
-      - name: List files to make sure we are on the right track, which we should be!
-        run: echo "Build directory:" && ls -A build && echo "Repository:" && ls -A
-        
       - name: Create package.nw directories
         run: mkdir build/KitsuneOffline-linux-x64/package.nw && mkdir build/KitsuneOffline-win-x64/package.nw && mkdir build/KitsuneOffline-linux-ia32/package.nw && mkdir build/KitsuneOffline-win-ia32/package.nw
         
@@ -64,9 +61,6 @@ jobs:
         
       - name: Create Linux archives
         run: cd build && tar -czvf KitsuneOffline-linux-x64.tar.gz KitsuneOffline-linux-x64 && zip -r KitsuneOffline-linux-ia32.tar.gz KitsuneOffline-linux-ia32
-        
-      - name: List files again
-        run: echo "Build directory:" && ls -A build && echo "Repository:" && ls -A
         
       - name: Upload Windows x64 build
         uses: actions/upload-artifact@v2

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -1,0 +1,30 @@
+name: BUild NW.js apps
+
+on:
+  [push, workflow_dispatch]
+  
+jobs:
+  build:
+    name: BUild Windows app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get repository code
+        uses: actions/checkout@v2
+        
+      - name: Download NW.js
+        run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-win-x64.zip
+        
+      - name: Extract NW.js
+        run: unzip nwjs-v0.55.0-win-x64.zip
+  build:
+    name: Build Linux app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get repository code
+        uses: actions/checkout@v2
+      
+      - name: Download NW.js
+        run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-linux-x64.tar.gz
+        
+      - name: Extract NW.js
+        run: unzip nwjs-v0.55.0-linux-x64.tar.gz

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -17,59 +17,77 @@ jobs:
       - name: Download Windows x64 NW.js
         run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-win-x64.zip
         
-      - name: Download Windows x86 NW.js
-        run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-win-x86.zip
+      - name: Download Windows ia32 NW.js
+        run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-win-ia32.zip
         
       - name: Download Linux x64 NW.js
         run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-linux-x64.tar.gz
         
-      - name: Download Linux x86 NW.js
-        run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-linux-x86.tar.gz
+      - name: Download Linux ia32 NW.js
+        run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-linux-ia32.tar.gz
         
       - name: Extract Windows x64 NW.js
         run: unzip nwjs-v0.55.0-win-x64.zip
         
-      - name: Extract Windows x86 NW.js
-        run: unzip nwjs-v0.55.0-win-x86.zip
+      - name: Extract Windows ia32 NW.js
+        run: unzip nwjs-v0.55.0-win-ia32.zip
         
       - name: Extract Linux x64 NW.js
         run: tar -xvf nwjs-v0.55.0-linux-x64.tar.gz
         
-      - name: Extract Linux x64 NW.js
-        run: tar -xvf nwjs-v0.55.0-linux-x64.tar.gz
+      - name: Extract Linux ia32 NW.js
+        run: tar -xvf nwjs-v0.55.0-linux-ia32.tar.gz
         
       - name: Delete archives
-        run: rm nwjs-v0.55.0-linux-x64.tar.gz nwjs-v0.55.0-win-x64.zip
+        run: rm nwjs-v0.55.0-linux-x64.tar.gz nwjs-v0.55.0-win-x64.zip nwjs-v0.55.0-linux-ia32.tar.gz nwjs-v0.55.0-win-ia32.zip
         
       - name: Rename and move NW.js directories
-        run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win
+        run: mv nwjs-v0.55.0-linux-x64 build/KitsuneOffline-linux-x64 && mv nwjs-v0.55.0-win-x64 build/KitsuneOffline-win-x64 && mv nwjs-v0.55.0-linux-ia32 build/KitsuneOffline-linux-ia32 && mv nwjs-v0.55.0-win-ia32 build/KitsuneOffline-win-ia32
         
       - name: List files to make sure we are on the right track, which we should be!
         run: echo "Build directory:" && ls -A build && echo "Repository:" && ls -A
         
       - name: Create package.nw directories
-        run: mkdir build/KitsuneOffline-linux/package.nw && mkdir build/KitsuneOffline-win/package.nw
+        run: mkdir build/KitsuneOffline-linux-x64/package.nw && mkdir build/KitsuneOffline-win-x64/package.nw && mkdir build/KitsuneOffline-linux-ia32 && mkdir build/KitsuneOffline-win-ia32
         
-      - name: Copy code to NW.js directories
-        run: cp -r logos build/KitsuneOffline-linux/package.nw && cp package.json build/KitsuneOffline-linux/package.nw && cp -r logos build/KitsuneOffline-win/package.nw && cp package.json build/KitsuneOffline-win/package.nw
+      - name: Copy logos to NW.js directories
+        run: cp -r logos build/KitsuneOffline-linux-x64/package.nw && cp -r logos build/KitsuneOffline-win-x64/package.nw && cp -r logos build/KitsuneOffline-linux-ia32/package.nw && cp -r logos build/KitsuneOffline-win-ia32/package.nw
         
-      - name: create Windows archive
-        run: cd build && zip -r KitsuneOffline-win.zip KitsuneOffline-win
+      - name: Copy package.json to NW.js directories
+        run: cp package.json build/KitsuneOffline-linux-x64/package.nw && cp package.json build/KitsuneOffline-win-x64/package.nw && cp package.json build/KitsuneOffline-linux-ia32/package.nw && cp package.json build/KitsuneOffline-win-ia32/package.nw
+    
+      - name: Rename executables
+        run: mv build/KitsuneOffline-linux-x64/nw build/KitsuneOffline-linux-x64/kitsune && mv build/KitsuneOffline-linux-ia32/nw build/KitsuneOffline-linux-ia32/kitsune && mv build/KitsuneOffline-win-x64/nw.exe build/KitsuneOffline-win-x64/kitsune.exe && mv build/KitsuneOffline-win-ia32/nw.exe build/KitsuneOffline-win-ia32/kitsune.exe
+    
+      - name: Create Windows archives
+        run: cd build && zip -r KitsuneOffline-win-x64.zip KitsuneOffline-win-x64 && zip -r KitsuneOffline-win-ia32.zip KitsuneOffline-win-ia32
         
-      - name: create Linux archive
-        run: cd build && tar -czvf KitsuneOffline-linux.tar.gz KitsuneOffline-linux
+      - name: Create Linux archives
+        run: cd build && tar -czvf KitsuneOffline-linux-x64.tar.gz KitsuneOffline-linux-x64 && zip -r KitsuneOffline-linux-ia32.tar.gz KitsuneOffline-linux-ia32
         
-      - name: list files again
+      - name: List files again
         run: echo "Build directory:" && ls -A build && echo "Repository:" && ls -A
         
-      - name: Upload Windows build
+      - name: Upload Windows x64 build
         uses: actions/upload-artifact@v2
         with:
-          name: KitsuneOffline-win.zip
-          path: build/KitsuneOffline-win.zip
+          name: KitsuneOffline-win-x64.zip
+          path: build/KitsuneOffline-win-x64.zip
           
-      - name: Upload Linux build
+      - name: Upload Linux x64 build
         uses: actions/upload-artifact@v2
         with:
-          name: KitsuneOffline-linux.tar.gz
-          path: build/KitsuneOffline-linux.tar.gz
+          name: KitsuneOffline-linux-x64.tar.gz
+          path: build/KitsuneOffline-linux-x64.tar.gz
+          
+      - name: Upload Windows ia32 build
+        uses: actions/upload-artifact@v2
+        with:
+          name: KitsuneOffline-win-ia32.zip
+          path: build/KitsuneOffline-win-ia32.zip
+          
+      - name: Upload Linux ia32 build
+        uses: actions/upload-artifact@v2
+        with:
+          name: KitsuneOffline-linux-ia32.tar.gz
+          path: build/KitsuneOffline-linux-ia32.tar.gz

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Create Linux archives
         run: cd build && tar -czvf KitsuneOffline-linux-x64.tar.gz KitsuneOffline-linux-x64 && tar -czvf KitsuneOffline-linux-ia32.tar.gz KitsuneOffline-linux-ia32
         
-      - name: Create MacOS archives
+      - name: Create MacOS archive
         run: cd build && zip -r KitsuneOffline-osx.zip Kitsune.app
         
       - name: Upload Windows x64 build

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -21,7 +21,7 @@ jobs:
         run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-linux-x64.tar.gz
         
       - name: Extract Linux NW.js
-        run: unzip nwjs-v0.55.0-linux-x64.tar.gz
+        run: tar -xvf nwjs-v0.55.0-linux-x64.tar.gz
         
       - name: list files
         run: ls

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo "Build directory:" && ls -A build && echo "Repository:" && ls -A
         
       - name: Create package.nw directories
-        run: mkdir build/KitsuneOffline-linux-x64/package.nw && mkdir build/KitsuneOffline-win-x64/package.nw && mkdir build/KitsuneOffline-linux-ia32 && mkdir build/KitsuneOffline-win-ia32
+        run: mkdir build/KitsuneOffline-linux-x64/package.nw && mkdir build/KitsuneOffline-win-x64/package.nw && mkdir build/KitsuneOffline-linux-ia32/package.nw && mkdir build/KitsuneOffline-win-ia32/package.nw
         
       - name: Copy logos to NW.js directories
         run: cp -r logos build/KitsuneOffline-linux-x64/package.nw && cp -r logos build/KitsuneOffline-win-x64/package.nw && cp -r logos build/KitsuneOffline-linux-ia32/package.nw && cp -r logos build/KitsuneOffline-win-ia32/package.nw

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -55,7 +55,22 @@ jobs:
     
       - name: Rename executables
         run: mv build/KitsuneOffline-linux-x64/nw build/KitsuneOffline-linux-x64/kitsune && mv build/KitsuneOffline-linux-ia32/nw build/KitsuneOffline-linux-ia32/kitsune && mv build/KitsuneOffline-win-x64/nw.exe build/KitsuneOffline-win-x64/kitsune.exe && mv build/KitsuneOffline-win-ia32/nw.exe build/KitsuneOffline-win-ia32/kitsune.exe
-    
+        
+      - name: Create Debian installer file structure
+        run: mkdir build/KitsuneOffline-debian-x64 && mkdir build/KitsuneOffline-debian-x64/usr && mkdir mkdir build/KitsuneOffline-debian-x64/DEBIAN && mkdir build/KitsuneOffline-debian-x64/usr/bin && mkdir build/KitsuneOffline-debian-x64/usr/lib && mkdir build/KitsuneOffline-debian-x64/usr/share && mkdir build/KitsuneOffline-debian-x64/usr/share/applications
+        
+      - name: Copy Linux build to Debian installer
+        run: cp -r build/KitsuneOffline-linux-x64 build/KitsuneOffline-debian-x64/usr/lib
+        
+      - name: Create Symlink to command
+        run: cd build/KitsuneOffline-debian-x64/usr/bin && ln -s ../lib/KitsuneOffline-linux-x64/kitsune
+        
+      - name: Copy control file
+        run: cp DEBIAN/control build/KitsuneOffline-debian-x64/DEBIAN
+        
+      - name: Copy desktop file
+        run: cp kitsune.desktop build/KitsuneOffline-debian-x64/usr/share/applications
+        
       - name: Create Windows archives
         run: cd build && zip -r KitsuneOffline-win-x64.zip KitsuneOffline-win-x64 && zip -r KitsuneOffline-win-ia32.zip KitsuneOffline-win-ia32
         

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -11,6 +11,9 @@ jobs:
       - name: Get repository code
         uses: actions/checkout@v2
         
+      - name: Create build directory and cd to it
+        run: mkdir build && cd build
+        
       - name: Download Windows NW.js
         run: wget https://dl.nwjs.io/v0.55.0/nwjs-v0.55.0-win-x64.zip
         
@@ -23,5 +26,11 @@ jobs:
       - name: Extract Linux NW.js
         run: tar -xvf nwjs-v0.55.0-linux-x64.tar.gz
         
-      - name: list files
-        run: ls
+      - name: Delete archives
+        run: rm nwjs-v0.55.0-linux-x64.tar.gz nwjs-v0.55.0-win-x64.zip
+        
+      - name: Rename NW.js directories
+        run: mv nwjs-v0.55.0-linux-x64 KitsuneOffline-linux && mv nwjs-v0.55.0-win-x64 KitsuneOffline-win
+        
+      - name: list files to make sure we are on the right track
+        run: ls && ls ..

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -50,3 +50,14 @@ jobs:
       - name: list files again
         run: echo "Build directory:" && ls -A build && echo "Repository:" && ls -A
         
+      - name: Upload Windows build
+        uses: actions/upload-artifact@v2
+        with:
+          name: KitsuneOffline-win.zip
+          path: build/KitsuneOffline-win.zip
+          
+      - name: Upload Linux build
+        uses: actions/upload-artifact@v2
+        with:
+          name: KitsuneOffline-linux.tar.gz
+          path: build/KitsuneOffline-linux.tar.gz

--- a/.github/workflows/buildnw.yml
+++ b/.github/workflows/buildnw.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Copy desktop file
         run: cp kitsune.desktop build/KitsuneOffline-debian-x64/usr/share/applications
         
+      - name: Create Debian installer
+        run: cd build && dpkg-deb --build KitsuneOffline-Debian-x64
+
       - name: Create Windows archives
         run: cd build && zip -r KitsuneOffline-win-x64.zip KitsuneOffline-win-x64 && zip -r KitsuneOffline-win-ia32.zip KitsuneOffline-win-ia32
         
@@ -100,3 +103,9 @@ jobs:
         with:
           name: KitsuneOffline-linux-ia32.tar.gz
           path: build/KitsuneOffline-linux-ia32.tar.gz
+
+      - name: Upload Debian installer build
+        uses: actions/upload-artifact@v2
+        with:
+          name: KitsuneOffline-debian-x64.deb
+          path: build/KitsuneOffline-debian-x64.deb

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,0 +1,8 @@
+Package: kitsune
+Version: 1.0
+Section: custom
+Priority: optional
+Architecture: amd64
+Essential: no
+Maintainer: Lennon McLean
+Description: An offline version of Google's Kitsune doodle game.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,11 @@ For pros (or if you just dont trust my executables):
 WHAT DO YOU MEAN YOU DONT TRUST SOME RANDOM DUDE ON THE INTERNETS EXECUTABLES???!!!    
 gosh okay, you wanna do it yourself? FINE    
     
-If you like living on the edge:  
-You can download the releases from Github Actions directly. NOTE: THESE BUILDS ARE CREATED AFTER EVERY COMMIT!!! That means that if a game-breaking bug gets accidentally introduced, then the build will be broken and not work. This is in contrast to the releases page where builds are tested before release.
-
 download the latest nw.js from: https://nwjs.io/downloads/,   
 then download the latest release of https://github.com/iteufel/nwjs-ffmpeg-prebuilt and replace nwjs ffmpeg.dll with that one   
 (this makes video playback work)    
    
 finally copy package.json and logos/ from this repository into the NWJS folder. start nw.exe and your done   
    
+If you like living on the edge:  
+You can download the releases from Github Actions directly. NOTE: THESE BUILDS ARE CREATED AFTER EVERY COMMIT!!! That means that if a game-breaking bug gets accidentally introduced, then the build will be broken and not work. This is in contrast to the releases page where builds are tested before release.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # KitsuneOffline
+
+![CI/CD Badge](https://github.com/thecoder08/KitsuneOffline/actions/workflows/buildnw.yml/badge.svg)
+
 Local Offline version of Kitsune Google Doodle, (Doodle Champion Island Games) 
 useful if you want to play without internet (or just want to mod the game)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ For pros (or if you just dont trust my executables):
 WHAT DO YOU MEAN YOU DONT TRUST SOME RANDOM DUDE ON THE INTERNETS EXECUTABLES???!!!    
 gosh okay, you wanna do it yourself? FINE    
     
+If you like living on the edge:  
+You can download the releases from Github Actions directly. NOTE: THESE BUILDS ARE CREATED AFTER EVERY COMMIT!!! That means that if a game-breaking bug gets accidentally introduced, then the build will be broken and not work. This is in contrast to the releases page where builds are tested before release.
+
 download the latest nw.js from: https://nwjs.io/downloads/,   
 then download the latest release of https://github.com/iteufel/nwjs-ffmpeg-prebuilt and replace nwjs ffmpeg.dll with that one   
 (this makes video playback work)    

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KitsuneOffline
 
-![CI/CD Badge](https://github.com/thecoder08/KitsuneOffline/actions/workflows/buildnw.yml/badge.svg)
+![CI/CD Badge](https://github.com/KuromeSan/KitsuneOffline/actions/workflows/buildnw.yml/badge.svg)
 
 Local Offline version of Kitsune Google Doodle, (Doodle Champion Island Games) 
 useful if you want to play without internet (or just want to mod the game)

--- a/kitsune.desktop
+++ b/kitsune.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Kitsune
+Comment=An offline version of Google's Kitsune doodle game.
+Exec=kitsune
+Icon=/usr/lib/kitsune-linux-x64/package.nw/logos/favicon.ico
+Terminal=false
+Categories=Game;


### PR DESCRIPTION
This just sets up CI/CD with Github Actions to automatically build the app whenever the code changes. It builds the app for Windows and Linux (x86 and x64), MacOS, and provides a Debian .deb installer package. It doesn't (yet) create a MacOS .dmg installer or mobile versions. This CI/CD doesn't put the resulting builds on the releases page, instead they must be taken from Actions and put on the releases page whenever a new version is being created.